### PR TITLE
Neuer April branch, neuer Parameter "unload = 20" wenn dieser gesetzt…

### DIFF
--- a/E3DC_CONF.h
+++ b/E3DC_CONF.h
@@ -5,7 +5,7 @@
 //  Created by Eberhard Mayer on 16.08.18.
 //  Copyright © 2018 Eberhard Mayer. All rights reserved.
 //
-#define VERSION "2020.4.2.01"
+#define VERSION "2020.4.11.01" //April branch
 #ifndef E3DC_CONF_h
 #define E3DC_CONF_h
 
@@ -41,8 +41,8 @@ typedef struct {
     char aes_password[128];
     char logfile[128];
     bool wallbox,ext1,ext2,ext3,ext7,debug,htsat,htsun,openWB;
-    uint8_t wurzelzaehler,ladeschwelle, ladeende;
-    int32_t ht, untererLadekorridor, obererLadekorridor, minimumLadeleistung, maximumLadeleistung, wrleistung,peakshave;
+    uint8_t wurzelzaehler,ladeschwelle, ladeende, unload;
+    int32_t ht, untererLadekorridor, obererLadekorridor, minimumLadeleistung, maximumLadeleistung, wrleistung,peakshave,peakshsoc;
     float_t speichergroesse,winterminimum, sommermaximum,sommerladeende, einspeiselimit,
     hton, htoff, htsockel;
     

--- a/RscpExampleMain.cpp
+++ b/RscpExampleMain.cpp
@@ -608,7 +608,7 @@ int WBProcess(SRscpFrameBuffer * frameBuffer) {
         }
         if ((fPower_WB > 1000) && not (bWBmaxLadestrom)) { // Wallbox lädt
             if (WBchar6[1]==6) iWBMinimumPower = fPower_WB;
-            if (((fPower_Grid< -200)&&(fAvPower_Grid < -100)) && (iPower_Bat >= 0) && (WBchar6[1]<iMaxcurrent)){
+            if (((fPower_Grid< -200)&&(fAvPower_Grid < -100)) && ((iPower_Bat > iMinLade)||(iPower_Bat > iBattLoad)) && (WBchar6[1]<iMaxcurrent)){
                 WBchar6[1]++;
                 if ((fPower_Grid-iPower_Bat < -10*700) && (iPower_Bat >= 0)&& (WBchar6[1]<iMaxcurrent)) WBchar6[1]++;
                 if ((fPower_Grid-iPower_Bat < -9*700) && (iPower_Bat >= 0)&& (WBchar6[1]<iMaxcurrent)) WBchar6[1]++;


### PR DESCRIPTION
… wird, wird der Speicher am Vormittag bis zum Beginn der Regelzeit auf z.B. 20% entladen um ausreichend Speicher für die Überschussregelung frei zu haben