### PR TITLE
Warnings in awattar.cpp beim Kompilieren behoben

### DIFF
--- a/awattar.cpp
+++ b/awattar.cpp
@@ -433,7 +433,7 @@ int ladedauer = 4;
     time(&rawtime);
     ptm = gmtime (&rawtime);
 
-    int64_t von, bis;
+    long long unsigned int von, bis;
     if (simu)
     {
         von = (rawtime-30*24*3600)*1000;


### PR DESCRIPTION
Ich habe selbst noch keine E3DC Anlage zuhaue stehen, um die  Änderung ausgiebig zu testen. Diese Änderung behebt auf jeden Fall die Warnings.